### PR TITLE
Update panels.Rmd

### DIFF
--- a/vignettes/panels.Rmd
+++ b/vignettes/panels.Rmd
@@ -17,7 +17,7 @@ output:
 date: "`r doc_date()`"
 package: "`r pkg_ver('iSEEtree')`"
 vignette: >
-    %\VignetteIndexEntry{iSEEtree}
+    %\VignetteIndexEntry{Panel Catalogue}
     %\VignetteEngine{knitr::rmarkdown}
     %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
to have the name rendered correctly on Bioc - at the moment, both vignettes are "called" `iSEEtree` there